### PR TITLE
Fix endpoint URLs for tool endpoints

### DIFF
--- a/docs/tools/brand-personality-match.md
+++ b/docs/tools/brand-personality-match.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/brand-personality-match
+GET /api/v2/tools/brand-personality-match
 ```
 
 ## Parameters

--- a/docs/tools/brand-vulnerability-map.md
+++ b/docs/tools/brand-vulnerability-map.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/brand-vulnerability-map
+GET /api/v2/tools/brand-vulnerability-map
 ```
 
 ## Parameters

--- a/docs/tools/brand-worth-map.md
+++ b/docs/tools/brand-worth-map.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/brand-worth-map
+GET /api/v2/tools/brand-worth-map
 ```
 
 ## Parameters

--- a/docs/tools/category-worth-map.md
+++ b/docs/tools/category-worth-map.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/category-worth-map
+GET /api/v2/tools/category-worth-map
 ```
 
 ## Parameters

--- a/docs/tools/commitment-funnel.md
+++ b/docs/tools/commitment-funnel.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/commitment-funnel
+GET /api/v2/tools/commitment-funnel
 ```
 
 ## Parameters

--- a/docs/tools/cost-of-entry.md
+++ b/docs/tools/cost-of-entry.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/cost-of-entry
+GET /api/v2/tools/cost-of-entry
 ```
 
 ## Parameters

--- a/docs/tools/love-plus.md
+++ b/docs/tools/love-plus.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/love-plus
+GET /api/v2/tools/love-plus
 ```
 
 ## Parameters

--- a/docs/tools/partnership-exchange-map.md
+++ b/docs/tools/partnership-exchange-map.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/partnership-exchange-map
+GET /api/v2/tools/partnership-exchange-map
 ```
 
 ## Parameters

--- a/docs/tools/swot.md
+++ b/docs/tools/swot.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/swot
+GET /api/v2/tools/swot
 ```
 
 ## Parameters

--- a/docs/tools/toplist-market.md
+++ b/docs/tools/toplist-market.md
@@ -3,7 +3,7 @@
 ## Creating a query
 
 ```http request
-GET /api/v2/toplist-market
+GET /api/v2/tools/toplist-market
 ```
 
 ## Parameters


### PR DESCRIPTION
This PR fixes an error in the endpoint URLs for the tool endpoint docs pages which were missing the /tools/ portion of the URL.