### PR TITLE
Fix relative links to core resources

### DIFF
--- a/docs/developer-tools/python/endpoints/brand-metric-groups.md
+++ b/docs/developer-tools/python/endpoints/brand-metric-groups.md
@@ -9,7 +9,7 @@ The `brand-metric-groups` endpoint has full support, including query validation.
 | ----------------------- | --------------------- | ---------------------------- | -------------------------- |
 | `"brand-metric-groups"` | `brand_metric_groups` | `Client.brand_metric_groups` | `BrandMetricGroupsFilters` |
 
-For more information on available filters and functionality, see the main API documentation for the [`brand-metric-groups` endpoint](/core-resources/brand-metric-groups.md).
+For more information on available filters and functionality, see the main API documentation for the [`brand-metric-groups` endpoint](/core-resources/metric-groups.md).
 
 ## Usage
 

--- a/docs/developer-tools/python/endpoints/brand-metrics.md
+++ b/docs/developer-tools/python/endpoints/brand-metrics.md
@@ -9,7 +9,7 @@ The `brand-metrics` endpoint has full support, including query validation.
 | ----------------- | --------------- | ---------------------- | --------------------- |
 | `"brand-metrics"` | `brand_metrics` | `Client.brand_metrics` | `BrandMetricsFilters` |
 
-For more information on available filters and functionality, see the main API documentation for the [`brand-metrics` endpoint](/core-resources/brand-metrics.md).
+For more information on available filters and functionality, see the main API documentation for the [`brand-metrics` endpoint](/core-resources/metrics.md).
 
 ## Usage
 


### PR DESCRIPTION
Fixed relative links to core resources for `brand-metrics` and `brand-metric-groups` endpoint pages.